### PR TITLE
Create install script

### DIFF
--- a/.github/workflows/lintr.yaml
+++ b/.github/workflows/lintr.yaml
@@ -4,6 +4,11 @@ on:
     branches:
       - master
       - dev
+  pull_request:
+    branches:
+      - master
+      - dev
+
 jobs:
   Lintr:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -30,4 +30,4 @@ jobs:
 
         $carlisle --runmode=init --workdir=./
         docker run -v $PWD:/opt2 snakemake/snakemake:v7.19.1 /bin/bash -c \
-          snakemake --dryrun --configfile config_lint.yaml
+          snakemake --dryrun -c 1 --configfile config_lint.yaml

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -20,10 +20,11 @@ jobs:
     - name: dryrun
       shell: bash {0}
       run: |
+        for dir in workflow config resources
+        do 
+          cp -r $dir .test
+        done
         cd .test
-        cp -r ../workflow ./
-        cp -r ../config ./
-        cp -r ../resources ./
         mkdir annotation
         for f in hg38.fa genes.gtf hg38.bed hg38.tss.bed hg38_refseq.ucsc Ecoli_GCF_000005845.2_ASM584v2_genomic.fna adapters.fa
         do

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -21,13 +21,14 @@ jobs:
       shell: bash {0}
       run: |
         ./install.sh carlisle-dev
-        echo $PATH
+        echo "$(readlink -f carlisle-dev)" >> $GITHUB_PATH
         cd .test
         mkdir annotation
         for f in hg38.fa genes.gtf hg38.bed hg38.tss.bed hg38_refseq.ucsc Ecoli_GCF_000005845.2_ASM584v2_genomic.fna adapters.fa
         do
           touch annotation/$f
         done
+
         which carlisle
         carlisle --runmode=init --workdir=./
         docker run -v $PWD:/opt2 snakemake/snakemake:v7.19.1 /bin/bash -c \

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -13,12 +13,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v4.1.0
     - uses: docker://snakemake/snakemake:v7.19.1
       with:
         directory: '.test'
     - name: dryrun
       run: |
-        echo $PWD
         bash ./install.sh carlisle-dev
         cd .test
         mkdir annotation

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -30,4 +30,4 @@ jobs:
 
         $carlisle --runmode=init --workdir=./
         docker run -v $PWD:/opt2 snakemake/snakemake:v7.19.1 /bin/bash -c \
-          $carlisle --runmode=dryrun --workdir=./ --configfile config_lint.yaml
+          snakemake --dryrun --configfile config_lint.yaml

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -32,4 +32,4 @@ jobs:
         done
 
         docker run -v $PWD:/opt2 snakemake/snakemake:v7.19.1 /bin/bash -c \
-          "echo $(ls .) && snakemake --dryrun -s workflow/Snakefile --configfile config_lint.yaml"
+          "snakemake --dryrun -s workflow/Snakefile --configfile config_lint.yaml"

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -23,7 +23,6 @@ jobs:
         ./install.sh .test/
         cd .test
         mv bin/* ./
-        ls .
 
         mkdir annotation
         for f in hg38.fa genes.gtf hg38.bed hg38.tss.bed hg38_refseq.ucsc Ecoli_GCF_000005845.2_ASM584v2_genomic.fna adapters.fa
@@ -31,5 +30,5 @@ jobs:
           touch annotation/$f
         done
 
-        docker run -v $PWD:/opt2 snakemake/snakemake:v7.19.1 /bin/bash -c \
-          "snakemake --dryrun -s workflow/Snakefile --configfile config_lint.yaml"
+        docker run -v $PWD:/data2 snakemake/snakemake:v7.19.1 /bin/bash -c \
+          "cd /data2 && snakemake --dryrun --configfile config_lint.yaml"

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: docker://snakemake/snakemake:v7.19.1
       with:
         directory: '.test'
-    - name: Dev Testing Workflow
+    - name: dryrun
       continue-on-error: true
       run: |
         docker run -v $PWD:/opt2 snakemake/snakemake:v7.19.1 /bin/bash -c \
@@ -20,6 +20,5 @@ jobs:
           cp /opt2/resources/tools_biowulf.yaml /opt2/output_carlisle/config/tools.yaml && \
           cd /opt2/output_carlisle/annotation && \
           touch hg38.fa genes.gtf hg38.bed hg38.tss.bed hg38_refseq.ucsc Ecoli_GCF_000005845.2_ASM584v2_genomic.fna adapters.fa && \
-          snakemake --lint -s /opt2/workflow/Snakefile \
-          -d /opt2/output_carlisle --configfile /opt2/.test/config_lint.yaml || \
-          echo 'There may have been a few warnings or errors. Please read through the log to determine if its harmless.'"
+          snakemake --dryrun -s /opt2/workflow/Snakefile \
+          -d /opt2/output_carlisle --configfile /opt2/.test/config_lint.yaml

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -32,5 +32,4 @@ jobs:
         done
 
         docker run -v $PWD:/opt2 snakemake/snakemake:v7.19.1 /bin/bash -c \
-          "ls ."
-          #" && snakemake --dryrun -c 1 --configfile config_lint.yaml"
+          "echo $(ls .) && snakemake --dryrun -s workflow/Snakefile --configfile config_lint.yaml"

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -20,8 +20,7 @@ jobs:
     - name: dryrun
       shell: bash {0}
       run: |
-        ./install.sh carlisle-dev
-        echo "$(readlink -f carlisle-dev)" >> $GITHUB_PATH
+        carlisle_path=$(./install.sh carlisle-dev)
         cd .test
         mkdir annotation
         for f in hg38.fa genes.gtf hg38.bed hg38.tss.bed hg38_refseq.ucsc Ecoli_GCF_000005845.2_ASM584v2_genomic.fna adapters.fa
@@ -29,7 +28,6 @@ jobs:
           touch annotation/$f
         done
 
-        which carlisle
-        carlisle --runmode=init --workdir=./
+        $carlisle_path --runmode=init --workdir=./
         docker run -v $PWD:/opt2 snakemake/snakemake:v7.19.1 /bin/bash -c \
-          carlisle --runmode=dryrun --workdir=./ --configfile config_lint.yaml
+          $carlisle_path --runmode=dryrun --workdir=./ --configfile config_lint.yaml

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -19,12 +19,13 @@ jobs:
     - name: dryrun
       continue-on-error: true
       run: |
+        bash install.sh carlisle-dev
+        which carlisle
+        cd .test
+        mkdir annotation
+        for f in hg38.fa genes.gtf hg38.bed hg38.tss.bed hg38_refseq.ucsc Ecoli_GCF_000005845.2_ASM584v2_genomic.fna adapters.fa
+        do
+          touch annotation/$f
+        done
         docker run -v $PWD:/opt2 snakemake/snakemake:v7.19.1 /bin/bash -c \
-          "mkdir -p /opt2/output_carlisle/config /opt2/output_carlisle/annotation && \
-          cp -r /opt2/workflow/scripts/ /opt2/output_carlisle/ && \
-          cp /opt2/resources/cluster_biowulf.yaml /opt2/output_carlisle/config/cluster.yaml && \
-          cp /opt2/resources/tools_biowulf.yaml /opt2/output_carlisle/config/tools.yaml && \
-          cd /opt2/output_carlisle/annotation && \
-          touch hg38.fa genes.gtf hg38.bed hg38.tss.bed hg38_refseq.ucsc Ecoli_GCF_000005845.2_ASM584v2_genomic.fna adapters.fa && \
-          snakemake --dryrun -s /opt2/workflow/Snakefile \
-          -d /opt2/output_carlisle --configfile /opt2/.test/config_lint.yaml
+          snakemake --dryrun --configfile config_lint.yaml

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -20,16 +20,17 @@ jobs:
     - name: dryrun
       shell: bash {0}
       run: |
-        for dir in workflow config resources
+        # TODO: install & use `carlisle init` instead of manually copying files
+        mkdir output_carlisle
+        for dir in workflow scripts config resources
         do 
-          cp -r $dir .test
+          cp -r $dir output_carlisle
         done
-        cd .test
-        mkdir annotation
+        mkdir output_carlisle/annotation
         for f in hg38.fa genes.gtf hg38.bed hg38.tss.bed hg38_refseq.ucsc Ecoli_GCF_000005845.2_ASM584v2_genomic.fna adapters.fa
         do
-          touch annotation/$f
+          touch output_carlisle/annotation/$f
         done
-
-        docker run -v $PWD:/data2 snakemake/snakemake:v7.19.1 /bin/bash -c \
-          "cd /data2 && snakemake --dryrun --configfile config_lint.yaml"
+        # TODO: use `carlisle run --mode dryrun`
+        docker run -v $PWD:/opt2/output_carlisle snakemake/snakemake:v7.19.1 /bin/bash -c \
+          "cd /opt2/output_carlisle && snakemake --dryrun --configfile config_lint.yaml"

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -33,4 +33,4 @@ jobs:
         done
         # TODO: use `carlisle run --mode dryrun`
         docker run -v $PWD:/opt2/output_carlisle snakemake/snakemake:v7.19.1 /bin/bash -c \
-          "cd /opt2/output_carlisle && snakemake --dryrun --configfile config_lint.yaml"
+          "cd /opt2/output_carlisle && snakemake --dryrun --configfile .test/config_lint.yaml"

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -17,7 +17,6 @@ jobs:
       with:
         directory: '.test'
     - name: dryrun
-      continue-on-error: true
       run: |
         bash install.sh carlisle-dev
         which carlisle

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -20,14 +20,15 @@ jobs:
     - name: dryrun
       shell: bash {0}
       run: |
-        carlisle=$(./install.sh carlisle-dev)/carlisle
+        ./install.sh .test/
         cd .test
+        mv bin/* ./
+
         mkdir annotation
         for f in hg38.fa genes.gtf hg38.bed hg38.tss.bed hg38_refseq.ucsc Ecoli_GCF_000005845.2_ASM584v2_genomic.fna adapters.fa
         do
           touch annotation/$f
         done
 
-        $carlisle --runmode=init --workdir=./
         docker run -v $PWD:/opt2 snakemake/snakemake:v7.19.1 /bin/bash -c \
           snakemake --dryrun -c 1 --configfile config_lint.yaml

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -20,10 +20,10 @@ jobs:
     - name: dryrun
       shell: bash {0}
       run: |
-        ./install.sh .test/
         cd .test
-        mv bin/* ./
-
+        cp -r ../workflow ./
+        cp -r ../config ./
+        cp -r ../resources ./
         mkdir annotation
         for f in hg38.fa genes.gtf hg38.bed hg38.tss.bed hg38_refseq.ucsc Ecoli_GCF_000005845.2_ASM584v2_genomic.fna adapters.fa
         do

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -2,7 +2,13 @@ name: DevTesting
 on:
   push:
     branches:
+      - master
       - dev
+  pull_request:
+    branches:
+      - master
+      - dev
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -20,7 +20,7 @@ jobs:
     - name: dryrun
       shell: bash {0}
       run: |
-        carlisle_path=$(./install.sh carlisle-dev)
+        carlisle=$(./install.sh carlisle-dev)/carlisle
         cd .test
         mkdir annotation
         for f in hg38.fa genes.gtf hg38.bed hg38.tss.bed hg38_refseq.ucsc Ecoli_GCF_000005845.2_ASM584v2_genomic.fna adapters.fa
@@ -28,6 +28,6 @@ jobs:
           touch annotation/$f
         done
 
-        $carlisle_path --runmode=init --workdir=./
+        $carlisle --runmode=init --workdir=./
         docker run -v $PWD:/opt2 snakemake/snakemake:v7.19.1 /bin/bash -c \
-          $carlisle_path --runmode=dryrun --workdir=./ --configfile config_lint.yaml
+          $carlisle --runmode=dryrun --workdir=./ --configfile config_lint.yaml

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -24,6 +24,7 @@ jobs:
         cd .test
         mv bin/* ./
         ls .
+
         mkdir annotation
         for f in hg38.fa genes.gtf hg38.bed hg38.tss.bed hg38_refseq.ucsc Ecoli_GCF_000005845.2_ASM584v2_genomic.fna adapters.fa
         do
@@ -31,4 +32,5 @@ jobs:
         done
 
         docker run -v $PWD:/opt2 snakemake/snakemake:v7.19.1 /bin/bash -c \
-          "ls . && snakemake --dryrun -c 1 --configfile config_lint.yaml"
+          "ls ."
+          #" && snakemake --dryrun -c 1 --configfile config_lint.yaml"

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -18,8 +18,9 @@ jobs:
       with:
         directory: '.test'
     - name: dryrun
+      shell: bash {0}
       run: |
-        bash ./install.sh carlisle-dev
+        ./install.sh carlisle-dev
         echo $PATH
         cd .test
         mkdir annotation

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         # TODO: install & use `carlisle init` instead of manually copying files
         mkdir output_carlisle
-        for dir in workflow scripts config resources
+        for dir in workflow workflow/scripts config resources
         do 
           cp -r $dir output_carlisle
         done

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -20,6 +20,7 @@ jobs:
     - name: dryrun
       run: |
         bash ./install.sh carlisle-dev
+        echo $PATH
         cd .test
         mkdir annotation
         for f in hg38.fa genes.gtf hg38.bed hg38.tss.bed hg38_refseq.ucsc Ecoli_GCF_000005845.2_ASM584v2_genomic.fna adapters.fa

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -23,7 +23,7 @@ jobs:
         ./install.sh .test/
         cd .test
         mv bin/* ./
-
+        ls .
         mkdir annotation
         for f in hg38.fa genes.gtf hg38.bed hg38.tss.bed hg38_refseq.ucsc Ecoli_GCF_000005845.2_ASM584v2_genomic.fna adapters.fa
         do
@@ -31,4 +31,4 @@ jobs:
         done
 
         docker run -v $PWD:/opt2 snakemake/snakemake:v7.19.1 /bin/bash -c \
-          "snakemake --dryrun -c 1 --configfile config_lint.yaml"
+          "ls . && snakemake --dryrun -c 1 --configfile config_lint.yaml"

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -18,13 +18,15 @@ jobs:
         directory: '.test'
     - name: dryrun
       run: |
-        bash install.sh carlisle-dev
-        which carlisle
+        echo $PWD
+        bash ./install.sh carlisle-dev
         cd .test
         mkdir annotation
         for f in hg38.fa genes.gtf hg38.bed hg38.tss.bed hg38_refseq.ucsc Ecoli_GCF_000005845.2_ASM584v2_genomic.fna adapters.fa
         do
           touch annotation/$f
         done
+        which carlisle
+        carlisle --runmode=init --workdir=./
         docker run -v $PWD:/opt2 snakemake/snakemake:v7.19.1 /bin/bash -c \
-          snakemake --dryrun --configfile config_lint.yaml
+          carlisle --runmode=dryrun --workdir=./ --configfile config_lint.yaml

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -31,4 +31,4 @@ jobs:
         done
 
         docker run -v $PWD:/opt2 snakemake/snakemake:v7.19.1 /bin/bash -c \
-          snakemake --dryrun -c 1 --configfile config_lint.yaml
+          "snakemake --dryrun -c 1 --configfile config_lint.yaml"

--- a/install.sh
+++ b/install.sh
@@ -38,3 +38,5 @@ cp ${DIRNAME}/resources/*.yaml ${INSTALL_PATH}/resources/
 if [[ ":$PATH:" != *":${INSTALL_PATH}:"* ]];then
     export PATH="${PATH}:${INSTALL_PATH}"
 fi
+
+echo "CARLISLE installed to ${INSTALL_PATH}"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# usage:
+#   ./install.sh new/path/to/install
+# example
+#   ./install.sh .v2.4.0
+
+SCRIPTNAME="$0"
+INSTALL_PATH="$1"
+
+DIRNAME=$(readlink -f $(dirname $0))
+
+
+mkdir -p ${INSTALL_PATH}
+
+
+if [ -n "$(ls -A $INSTALL_PATH 2>/dev/null)" ]
+then
+    echo "ERROR: directory not empty: ${INSTALL_PATH}"
+    exit 1
+fi
+
+# copy essential files & directories
+
+## carlisle CLI script
+cp $DIRNAME/carlisle $INSTALL_PATH/
+
+## all config & workflow scripts;
+for subdir in config workflow/scripts
+do  
+    mkdir -p ${INSTALL_PATH}/$subdir
+    cp ${DIRNAME}/$subdir/* ${INSTALL_PATH}/$subdir
+done
+
+## selected resources
+mkdir -p ${INSTALL_PATH}/resources/
+cp ${DIRNAME}/resources/*.yaml ${INSTALL_PATH}/resources/
+
+# export path
+if [[ ":$PATH:" != *":${INSTALL_PATH}:"* ]];then
+    export PATH="${PATH}:${INSTALL_PATH}"
+fi

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # usage:
 #   ./install.sh new/path/to/install
-# example
+# examples
 #   ./install.sh .v2.4.0
+#   /data/CCBR_Pipeliner/Pipelines/CARLISLE/dev/install.sh /data/CCBR_Pipeliner/Pipelines/CARLISLE/.v2.5.0-a
 
 SCRIPTNAME="$0"
 INSTALL_PATH="$1"

--- a/install.sh
+++ b/install.sh
@@ -40,4 +40,4 @@ if [[ ":$PATH:" != *":${INSTALL_PATH}:"* ]];then
     export PATH="${PATH}:${INSTALL_PATH}"
 fi
 
-echo "Installed CARLISLE to ${INSTALL_PATH}"
+echo "${INSTALL_PATH}"

--- a/install.sh
+++ b/install.sh
@@ -7,13 +7,9 @@
 set -euxo pipefail
 
 VERSION=$1
-INSTALL_PATH=${VERSION}/bin
-
+mkdir -p ${VERSION}/bin
+INSTALL_PATH=$(readlink -f ${VERSION}/bin)
 DIRNAME=$(readlink -f $(dirname $0))
-
-
-mkdir -p ${INSTALL_PATH}
-
 
 if [ -n "$(ls -A $INSTALL_PATH 2>/dev/null)" ]
 then

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,7 @@
 # examples
 #   ./install.sh .v2.4.0
 #   /data/CCBR_Pipeliner/Pipelines/CARLISLE/dev/install.sh /data/CCBR_Pipeliner/Pipelines/CARLISLE/.v2.5.0-a
+set -euxo pipefail
 
 VERSION=$1
 INSTALL_PATH=${VERSION}/bin

--- a/install.sh
+++ b/install.sh
@@ -5,8 +5,8 @@
 #   ./install.sh .v2.4.0
 #   /data/CCBR_Pipeliner/Pipelines/CARLISLE/dev/install.sh /data/CCBR_Pipeliner/Pipelines/CARLISLE/.v2.5.0-a
 
-SCRIPTNAME="$0"
-INSTALL_PATH="$1"
+VERSION=$1
+INSTALL_PATH=${VERSION}/bin
 
 DIRNAME=$(readlink -f $(dirname $0))
 

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ fi
 cp $DIRNAME/carlisle $INSTALL_PATH/
 
 ## all config & workflow scripts;
-for subdir in config workflow/scripts
+for subdir in config workflow/scripts workflow/Snakefile
 do  
     mkdir -p ${INSTALL_PATH}/$subdir
     cp ${DIRNAME}/$subdir/* ${INSTALL_PATH}/$subdir

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,7 @@ DIRNAME=$(readlink -f $(dirname $0))
 if [ -n "$(ls -A $INSTALL_PATH 2>/dev/null)" ]
 then
     echo "ERROR: directory not empty: ${INSTALL_PATH}"
+    echo $(ls $INSTALL_PATH)
     exit 1
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 # examples
 #   ./install.sh .v2.4.0
 #   /data/CCBR_Pipeliner/Pipelines/CARLISLE/dev/install.sh /data/CCBR_Pipeliner/Pipelines/CARLISLE/.v2.5.0-a
-set -euxo pipefail
+set -euo pipefail
 
 VERSION=$1
 mkdir -p ${VERSION}/bin
@@ -40,4 +40,4 @@ if [[ ":$PATH:" != *":${INSTALL_PATH}:"* ]];then
     export PATH="${PATH}:${INSTALL_PATH}"
 fi
 
-echo "CARLISLE installed to ${INSTALL_PATH}"
+echo "Installed CARLISLE to ${INSTALL_PATH}"

--- a/workflow/scripts/_spooker
+++ b/workflow/scripts/_spooker
@@ -35,10 +35,10 @@ if [[ $ISBIOWULF == true || $ISFRCE == true ]];then
 	    fi
         fi
         echo "spook is now in PATH:$SPOOK"
-        SPOOK_COPY2DIR="/scratch/carlisle"
+        SPOOK_COPY2DIR="/scratch/ccbrpipeliner"
     fi
     if [[ $ISFRCE == true ]];then
-        SPOOK_COPY2DIR="/mnt/projects/CCBR-Pipelines/pipelines/userdata/carlisle"
+        SPOOK_COPY2DIR="/mnt/projects/CCBR-Pipelines/pipelines/userdata/ccbrpipeliner"
     fi
 
     DT=$(date +%y%m%d%H%M%S)
@@ -63,8 +63,8 @@ if [[ $ISBIOWULF == true || $ISFRCE == true ]];then
         tree $PIPELINE_OUTDIR >> $treefile
         cmd="$cmd $treefile"
 
-        if [[ -d "${PIPELINE_OUTDIR}/logfiles" ]];then
-            logdir="${PIPELINE_OUTDIR}/logfiles"
+        if [[ -d "${PIPELINE_OUTDIR}/logs" ]];then
+            logdir="${PIPELINE_OUTDIR}/logs"
             for thisfile in "snakemake.log" "snakemake.log.jobby" "master.log" "runtime_statistics.json";do
                 absthisfile="${logdir}/${thisfile}"
                 if [[ -f "$absthisfile" ]];then


### PR DESCRIPTION
"install" meaning just copy the driver script plus essential files/directories to a designated location and adds it to the path.

~Also refactors the `test_dev` github action to use the carlisle interface for a dryrun.~ Actually we can't use the carlisle cli for a dryrun on github actions as it currently is now because it assumes the `module` command is available. Would have to refactor the cli first, and that's beyond the scope of this PR. Please ignore the embarrassingly long string of commits wherein I figured this out very slowly 😅

Resolves #91 