### PR TITLE
Test a dryrun with GitHub Actions

### DIFF
--- a/.github/workflows/lintr.yaml
+++ b/.github/workflows/lintr.yaml
@@ -4,6 +4,11 @@ on:
     branches:
       - master
       - dev
+  pull_request:
+    branches:
+      - master
+      - dev
+
 jobs:
   Lintr:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -20,8 +20,13 @@ jobs:
     - name: dryrun
       shell: bash {0}
       run: |
-        bash ./install.sh ./carlisle-v9999.9999.9999-dev
-        ./carlisle-v9999.9999.9999-dev/bin/carlisle --runmode=init --workdir=./output_carlisle
+        bash ./install.sh ./test-workdir/carlisle-v9999.9999.9999-dev
+        ./test-workdir/carlisle-v9999.9999.9999-dev/bin/carlisle --runmode=init --workdir=./test-workdir/output_carlisle
+        cp ./test-workdir/carlisle-v9999.9999.9999-dev/bin/.test/config_lint.yaml ./test-workdir/output_carlisle/config/config.yaml
         # TODO: use `carlisle run --mode dryrun`
-        docker run -v ./output_carlisle:/opt2/output_carlisle snakemake/snakemake:v7.19.1 /bin/bash -c \
-          "cd /opt2/output_carlisle && snakemake --dryrun --configfile .test/config_lint.yaml"
+        docker run -v ./test-workdir/:/opt2 snakemake/snakemake:v7.19.1 /bin/bash -c \
+          "cd /opt2 && snakemake \
+            -s ./carlisle-v9999.9999.9999-dev/bin/workflow/Snakefile \
+            --dryrun \
+            --configfile .test/config_lint.yaml\
+            --workdir /opt2/test-workdir/output_carlisle"

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -20,18 +20,8 @@ jobs:
     - name: dryrun
       shell: bash {0}
       run: |
-        # TODO: install & use `carlisle init` instead of manually copying files
-        mkdir output_carlisle
-        for dir in workflow workflow/scripts config resources
-        do 
-          cp -r $dir output_carlisle
-        done
-        mkdir output_carlisle/annotation
-        for f in hg38.fa genes.gtf hg38.bed hg38.tss.bed hg38_refseq.ucsc Ecoli_GCF_000005845.2_ASM584v2_genomic.fna adapters.fa
-        do
-          touch output_carlisle/annotation/$f
-        done
+        bash ./install.sh ./carlisle-v9999.9999.9999-dev
+        ./carlisle-v9999.9999.9999-dev/bin/carlisle --runmode=init --workdir=./output_carlisle
         # TODO: use `carlisle run --mode dryrun`
-        cd output_carlisle
-        docker run -v $PWD:/opt2/output_carlisle snakemake/snakemake:v7.19.1 /bin/bash -c \
+        docker run -v ./output_carlisle:/opt2/output_carlisle snakemake/snakemake:v7.19.1 /bin/bash -c \
           "cd /opt2/output_carlisle && snakemake --dryrun --configfile .test/config_lint.yaml"

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -28,5 +28,5 @@ jobs:
           "cd /opt2 && snakemake \
             -s ./carlisle-v9999.9999.9999-dev/bin/workflow/Snakefile \
             --dryrun \
-            --configfile .test/config_lint.yaml\
-            --workdir /opt2/test-workdir/output_carlisle"
+            --configfile carlisle-v9999.9999.9999-dev/bin/.test/config_lint.yaml \
+            --directory output_carlisle"

--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -1,25 +1,37 @@
-name: DevTesting
+name: test
 on:
   push:
     branches:
+      - master
       - dev
+  pull_request:
+    branches:
+      - master
+      - dev
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v4.1.0
     - uses: docker://snakemake/snakemake:v7.19.1
       with:
         directory: '.test'
-    - name: Dev Testing Workflow
-      continue-on-error: true
+    - name: dryrun
+      shell: bash {0}
       run: |
-        docker run -v $PWD:/opt2 snakemake/snakemake:v7.19.1 /bin/bash -c \
-          "mkdir -p /opt2/output_carlisle/config /opt2/output_carlisle/annotation && \
-          cp -r /opt2/workflow/scripts/ /opt2/output_carlisle/ && \
-          cp /opt2/resources/cluster_biowulf.yaml /opt2/output_carlisle/config/cluster.yaml && \
-          cp /opt2/resources/tools_biowulf.yaml /opt2/output_carlisle/config/tools.yaml && \
-          cd /opt2/output_carlisle/annotation && \
-          touch hg38.fa genes.gtf hg38.bed hg38.tss.bed hg38_refseq.ucsc Ecoli_GCF_000005845.2_ASM584v2_genomic.fna adapters.fa && \
-          snakemake --lint -s /opt2/workflow/Snakefile \
-          -d /opt2/output_carlisle --configfile /opt2/.test/config_lint.yaml || \
-          echo 'There may have been a few warnings or errors. Please read through the log to determine if its harmless.'"
+        # TODO: install & use `carlisle init` instead of manually copying files
+        mkdir output_carlisle
+        for dir in workflow workflow/scripts config resources
+        do 
+          cp -r $dir output_carlisle
+        done
+        mkdir output_carlisle/annotation
+        for f in hg38.fa genes.gtf hg38.bed hg38.tss.bed hg38_refseq.ucsc Ecoli_GCF_000005845.2_ASM584v2_genomic.fna adapters.fa
+        do
+          touch output_carlisle/annotation/$f
+        done
+        # TODO: use `carlisle run --mode dryrun`
+        cd output_carlisle
+        docker run -v $PWD:/opt2/output_carlisle snakemake/snakemake:v7.19.1 /bin/bash -c \
+          "cd /opt2/output_carlisle && snakemake --dryrun --configfile .test/config_lint.yaml"


### PR DESCRIPTION
## Changes

- Made the linter workflow run on all pushes & PRs to master & dev.
- Changed the test_dev workflow to:
  - Do a dryrun
  - Run on all pushes & PRs to master & dev.

Initially I wanted to have the test workflow use the new install script and use the carlisle CLI to init & dryrun, but currently the CLI assumes you're on biowulf/frce due to the module command. It's beyond the scope of this PR to refactor the CLI.