### PR TITLE
Add GitHub Action to add issues/PRs to personal project boards

### DIFF
--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -1,0 +1,14 @@
+name: Add issues/PRs to user projects
+
+on:
+  issues:
+    types:
+      - assigned
+  pull_request:
+    types:
+      - assigned
+
+jobs:
+  add-to-project:
+    uses: CCBR/.github/.github/workflows/auto-add-user-project.yml@v0.1.0
+    secrets: inherit


### PR DESCRIPTION
When a person is assigned to an issue or PR, it will be automatically added to their personal project board