### PR TITLE
fix singularity bind paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - New parameters in the config file to make certain rules optional: (#133, @kelly-sovacool)
     - GO enrichment is controlled by `run_go_enrichment` (default: `false`)
     - rose is controlled by `run_rose` (default: `false`)
-  
+- Fig bug that added nonexistent directories to the singularity bind paths. (#135, @kelly-sovacool)
 
 ## CARLISLE v2.5.0
 - Refactors R packages to a common source location (#118, @slsevilla)

--- a/bin/carlisle
+++ b/bin/carlisle
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+SCRIPTNAME="$BASH_SOURCE"
+SCRIPTDIRNAME=$(readlink -f $(dirname "$SCRIPTNAME"))
+
+TOOLDIR=$(dirname "$SCRIPTDIRNAME")
+TOOLNAME=$(basename "$SCRIPTNAME")
+
+${TOOLDIR}/carlisle "$@" || true

--- a/carlisle
+++ b/carlisle
@@ -140,22 +140,10 @@ function check_essential_files() {
 }
 
 function set_singularity_binds(){
-# this functions tries find what folders to bind
-# biowulf specific
-  # set extra singularity bindings
-  EXTRA_SINGULARITY_BINDS="/lscratch"
+  # TODO set based on detected HPC
+  BINDS="/lscratch"
 
-  echo "$PIPELINE_HOME" >> ${WORKDIR}/tmp1
-  echo "$WORKDIR" >> ${WORKDIR}/tmp1
-  grep -o '\/.*' <(cat ${WORKDIR}/config/config.yaml ${WORKDIR}/config/samples.tsv)|tr '\t' '\n'|grep -v ' \|\/\/'|sort|uniq >> ${WORKDIR}/tmp1
-  grep gpfs ${WORKDIR}/tmp1|awk -F'/' -v OFS='/' '{print $1,$2,$3,$4,$5}' |sort|uniq > ${WORKDIR}/tmp2
-  grep -v gpfs ${WORKDIR}/tmp1|awk -F'/' -v OFS='/' '{print $1,$2,$3}'|sort|uniq > ${WORKDIR}/tmp3
-  while read a;do readlink -f $a;done < ${WORKDIR}/tmp3 > ${WORKDIR}/tmp4
-  binds=$(cat ${WORKDIR}/tmp2 ${WORKDIR}/tmp3 ${WORKDIR}/tmp4|sort|uniq |tr '\n' ',')
-  rm -f ${WORKDIR}/tmp?
-  binds=$(echo $binds|awk '{print substr($1,1,length($1)-1)}')
-
-  SINGULARITY_BINDS=" -B $EXTRA_SINGULARITY_BINDS,$binds "
+  SINGULARITY_BINDS=" -B $BINDS,$WORKDIR "
 }
 
 function rescript(){


### PR DESCRIPTION
## Changes

The function to detect and set singularity bind paths based on the config files no longer worked -- it included directories that did not exist. It was also unnecessarily complicated -- only the workdir and lscratch are needed.

This PR also adds a simple wrapper script `bin/carlisle` so the usage will be the same as the other snakemake-based workflows.

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
