### PR TITLE
fix: remove singularity version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,18 @@
     - Ensures control replicate number is an integer.
     - Fixes FDR cutoff misassigned to log2FC cutoff.
     - Fixes `no_dedup` variable names in library normalization scripts.
-- Containerize rules that require R (`deseq`, `go_enrichment`, and `spikein_assessment`) to fix installation issues with common R library path. (#129, @kelly-sovacool)
-    - The `Rlib_dir` and `Rpkg_config` config options have been removed as they are no longer needed.
-- New visualizations: (#132, @epehrsson)
-    - New rules `cov_correlation`, `homer_enrich`, `combine_homer`, `count_peaks`
-    - Add peak caller to MACS2 peak xls filename
-- New parameters in the config file to make certain rules optional: (#133, @kelly-sovacool)
-    - GO enrichment is controlled by `run_go_enrichment` (default: `false`)
-    - ROSE is controlled by `run_rose` (default: `false`)
-- Fig bug that added nonexistent directories to the singularity bind paths. (#135, @kelly-sovacool)
+    - Fig bug that added nonexistent directories to the singularity bind paths. (#135, @kelly-sovacool)
+- New features:
+    - Containerize rules that require R (`deseq`, `go_enrichment`, and `spikein_assessment`) to fix installation issues with common R library path. (#129, @kelly-sovacool)
+        - The `Rlib_dir` and `Rpkg_config` config options have been removed as they are no longer needed.
+    - New visualizations: (#132, @epehrsson)
+        - New rules `cov_correlation`, `homer_enrich`, `combine_homer`, `count_peaks`
+        - Add peak caller to MACS2 peak xls filename
+    - New parameters in the config file to make certain rules optional: (#133, @kelly-sovacool)
+        - GO enrichment is controlled by `run_go_enrichment` (default: `false`)
+        - ROSE is controlled by `run_rose` (default: `false`)
+- Misc:
+    - The singularity version is no longer specified, per request of the biowulf admins. (#139, @kelly-sovacool)
 
 ## CARLISLE v2.5.0
 - Refactors R packages to a common source location (#118, @slsevilla)

--- a/carlisle
+++ b/carlisle
@@ -11,7 +11,7 @@
 
 PYTHON_VERSION="python/3.9"
 SNAKEMAKE_VERSION="snakemake/7.19.1"
-SINGULARITY_VERSION="singularity/3.10.5"
+SINGULARITY_VERSION="singularity"
 
 set -eo pipefail
 


### PR DESCRIPTION
## Changes

We can't specify the singularity version any more on biowulf. See https://github.com/CCBR/ccbrpipeliner/issues/45

## Issues

resolves #138

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
