### PR TITLE
fix: less specific module versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## CARLISLE development version
 
+- Load the module for snakemake v7, but do not specify the minor and patch versions. (#149, @kelly-sovacool)
+
 ## CARLISLE 2.6.0
 
 ### Bug fixes

--- a/carlisle
+++ b/carlisle
@@ -9,8 +9,7 @@
 #
 # DISCLAIMER: This wrapper only works on BIOWULF
 
-PYTHON_VERSION="python/3.9"
-SNAKEMAKE_VERSION="snakemake/7.19.1"
+SNAKEMAKE_VERSION="snakemake/7"
 SINGULARITY_VERSION="singularity"
 
 set -eo pipefail
@@ -156,7 +155,6 @@ function rescript(){
 function runcheck(){
 # Check "job-essential" files and load required modules
   check_essential_files
-  module load $PYTHON_VERSION
   module load $SNAKEMAKE_VERSION
 }
 
@@ -211,7 +209,6 @@ function runlocal() {
 }
 
 function runtest() {
-  module load $PYTHON_VERSION
   module load $SNAKEMAKE_VERSION
   module load $SINGULARITY_VERSION
   check_essential_files
@@ -301,7 +298,6 @@ function run() {
 #SBATCH --time=96:00:00
 #SBATCH --cpus-per-task=2
 
-    module load $PYTHON_VERSION
     module load $SNAKEMAKE_VERSION
     module load $SINGULARITY_VERSION
 


### PR DESCRIPTION

## Changes

just need snakemake v7, which also loads python

## Issues

fixes #148 

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
