### PR TITLE
fix: add jobby & spooker to path if not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## CARLISLE development version
 
 - Documentation improvements. (#154, @kelly-sovacool)
+- Try adding jobby & spooker to the path on workflow completion. (#155, @kelly-sovacool)
 
 ## CARLISLE 2.6.1
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -159,7 +159,7 @@ spikein_reference:
 
 adapters: "PIPELINE_HOME/resources/other/adapters.fa"
 
-tools_path: "/data/CCBR_Pipeliner/Tools/ccbr_tools/v0.1/bin/"
+tools_path: "/data/CCBR_Pipeliner/Tools/ccbr_tools/v0.2/bin/"
 #####################################################################################
 # CONTAINERS
 #####################################################################################

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -159,6 +159,7 @@ spikein_reference:
 
 adapters: "PIPELINE_HOME/resources/other/adapters.fa"
 
+tools_path: "/data/CCBR_Pipeliner/Tools/ccbr_tools/v0.1/bin/"
 #####################################################################################
 # CONTAINERS
 #####################################################################################

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -255,23 +255,25 @@ rule all:
         unpack(get_rose),
         unpack(get_enrichment)
 
-# create jobby tables
-jobby_cmd = 'run_jobby_on_snakemake_log logs/snakemake.log | tee logs/snakemake.log.jobby | cut -f2,3,18 > logs/snakemake.log.jobby.short'
-spook_cmd = f'spooker {WORKDIR} CARLISLE'
+on_complete = f"""
+for cmd in spooker run_jobby_on_snakemake_log; do
+    if ! command -v run_jobby_on_snakemake_log 2>&1 >/dev/null; then
+        export PATH="$PATH:{config['tools_path']}"
+    fi
+done
+run_jobby_on_snakemake_log logs/snakemake.log | tee logs/snakemake.log.jobby | cut -f2,3,18 > logs/snakemake.log.jobby.short
+spooker {WORKDIR} CARLISLE
+"""
 
 onsuccess:
     print("OnSuccess")
-    print(jobby_cmd)
-    shell(jobby_cmd)
-    print(spook_cmd)
-    shell(spook_cmd)
+    print(on_complete)
+    shell(on_complete)
 
 onerror:
     print("OnError")
-    print(jobby_cmd)
-    shell(jobby_cmd)
-    print(spook_cmd)
-    shell(spook_cmd)
+    print(on_complete)
+    shell(on_complete)
 
 """
         ##########################################

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -257,7 +257,7 @@ rule all:
 
 on_complete = f"""
 for cmd in spooker run_jobby_on_snakemake_log; do
-    if ! command -v run_jobby_on_snakemake_log 2>&1 >/dev/null; then
+    if ! command -v $cmd 2>&1 >/dev/null; then
         export PATH="$PATH:{config['tools_path']}"
     fi
 done


### PR DESCRIPTION
## Changes

If jobby or spooker aren't in the path, try adding them

## Issues

resolves #152

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
