### PR TITLE
Fix library size-based normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## CARLISLE development version
 
 - Documentation improvements. (#154, @kelly-sovacool)
+- Fix bug that flipped library normalization scaling factor (#157, @epehrsson)
 
 ## CARLISLE 2.6.1
 

--- a/workflow/scripts/_make_library_norm_table.R
+++ b/workflow/scripts/_make_library_norm_table.R
@@ -57,19 +57,19 @@ final_df <- data.frame()
 for (dedup_type in c("dedup_nreads_genome", "no_dedup_nreads_genome")) {
   # determine scaling factor dependent on library size
   col_median <- median(df[, dedup_type])
-  if (col_median > 1000000000) {
+  if (col_median > 100000000) {
     lib_factor <- 1e8
-  } else if (col_median > 100000000) {
-    lib_factor <- 1e7
   } else if (col_median > 10000000) {
-    lib_factor <- 1e6
+    lib_factor <- 1e7
   } else if (col_median > 1000000) {
-    lib_factor <- 1e5
+    lib_factor <- 1e6
   } else if (col_median > 100000) {
-    lib_factor <- 1e4
+    lib_factor <- 1e5
   } else if (col_median > 10000) {
-    lib_factor <- 1e3
+    lib_factor <- 1e4
   } else if (col_median > 1000) {
+    lib_factor <- 1e3
+  } else if (col_median > 100) {
     lib_factor <- 1e2
   } else {
     lib_factor <- 1e1

--- a/workflow/scripts/_make_library_norm_table.R
+++ b/workflow/scripts/_make_library_norm_table.R
@@ -75,7 +75,7 @@ for (dedup_type in c("dedup_nreads_genome", "no_dedup_nreads_genome")) {
     lib_factor <- 1e1
   }
 
-  df$library_size <- df[, dedup_type] / lib_factor
+  df$library_size <- lib_factor / df[, dedup_type]
   df$sampleid <- rownames(df)
   df$dedup_type <- strsplit(dedup_type, "_")[[1]][1]
   df$dedup_type <- gsub("no", "no_dedup", df$dedup_type)


### PR DESCRIPTION
## Changes

Fixes library size-based normalization error. Unlike spike-in-based normalization, read depth was multiplied by (library size / constant), rather than calculating read depth per library size (a la CPM). Also updated the scaling factor to approximate CPM.

## Issues

Fixes https://github.com/CCBR/CARLISLE/issues/157

## PR Checklist

- [x ] This comment contains a description of changes with justifications, with any relevant issues linked.
~- [ ] Update docs if there are any API changes.~
- [x ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
