### PR TITLE
fix: pd.to_csv() requires named keyword arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## CARLISLE development version
 
 - Minor documentation update to use readthedocs theme. (#162, @kelly-sovacool)
+- Fix deprecation warning during initialization. (#163, @kelly-sovacool)
 
 ## CARLISLE 2.6.2
 

--- a/workflow/rules/init.smk
+++ b/workflow/rules/init.smk
@@ -143,7 +143,7 @@ fpath=join(RESULTSDIR,"treatment_control_list.txt")
 originalDF = pd.DataFrame(TREAT_to_CONTRL_DICT.items()).rename(columns={0: 'key', 1: 'val'})
 split_keysDF = pd.DataFrame(originalDF['key'].str.split(':').tolist())
 finalDF = split_keysDF.join(originalDF['val'])
-finalDF.to_csv(fpath, '\t', header=False, index=False)
+finalDF.to_csv(fpath, sep='\t', header=False, index=False)
 
 # set treatment lists depending on whether controls were used for all peak callers
 # macs2 allows for with or without controls; all other callers require with controls
@@ -187,7 +187,7 @@ QTRESHOLDS=list(map(lambda x:x.strip(),QTRESHOLDS.split(",")))
 # set contrast settings
 if config["run_contrasts"]:
     print("#"*100)
-    print("# Checking constrasts to run...")
+    print("# Checking contrasts to run...")
     contrasts_table = config["contrasts"]
     check_readaccess(contrasts_table)
     contrasts_df=pd.read_csv(contrasts_table,sep="\t",header=0)


### PR DESCRIPTION
## Changes

name the keyword arguments in `pd.to_csv()`

## Issues

fixes #156

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
