### PR TITLE
fix: use ccbr base v7 which sets PYTHONPATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix how singularity bind paths are set. (#187, @kelly-sovacool)
 - Fix the DESeq rule when using the hs1 T2T genome. (#187, @kelly-sovacool, @wong-nw)
 - Fix incorrect jobby version (needs v0.4). (#194, @kelly-sovacool)
+- Fix numpy error. (#198, @kelly-sovacool)
 
 ## CARLISLE 2.7.1
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -164,8 +164,8 @@ ccbr_tools_path: "/data/CCBR_Pipeliner/Tools/ccbr_tools/v0.4/bin/"
 # CONTAINERS
 #####################################################################################
 containers:
-  base: "docker://nciccbr/ccbr_ubuntu_base_20.04:v6"
-  carlisle_r: "docker://nciccbr/carlisle_r:v4"
+  base: "docker://nciccbr/ccbr_ubuntu_base_20.04:v7"
+  carlisle_r: "docker://nciccbr/carlisle_r:v5"
 
 # Pipeline information
 pipeline: "CARLISLE"

--- a/docker/carlisle_r/Dockerfile
+++ b/docker/carlisle_r/Dockerfile
@@ -1,4 +1,4 @@
-FROM nciccbr/ccbr_ubuntu_base_20.04:v6
+FROM nciccbr/ccbr_ubuntu_base_20.04:v7
 
 # build time variables
 ARG BUILD_DATE="000000"

--- a/docker/carlisle_r/meta.yml
+++ b/docker/carlisle_r/meta.yml
@@ -1,4 +1,4 @@
 dockerhub_namespace: nciccbr
 image_name: carlisle_r
-version: v4
+version: v5
 container: "$(dockerhub_namespace)/$(image_name):$(version)"


### PR DESCRIPTION
## Changes

Bump container versions -- use ccbr base v7

## Issues

fixes #197

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
